### PR TITLE
fix(updater): Fix silent install conflict between client service

### DIFF
--- a/WinSparkle.vcxproj
+++ b/WinSparkle.vcxproj
@@ -218,6 +218,7 @@
     <ClCompile Include="src\dllmain.cpp" />
     <ClCompile Include="src\download.cpp" />
     <ClCompile Include="src\error.cpp" />
+    <ClCompile Include="src\service.cpp" />
     <ClCompile Include="src\settings.cpp" />
     <ClCompile Include="src\threads.cpp" />
     <ClCompile Include="src\ui.cpp" />
@@ -232,6 +233,7 @@
     <ClInclude Include="src\appcontroller.h" />
     <ClInclude Include="src\download.h" />
     <ClInclude Include="src\error.h" />
+    <ClInclude Include="src\service.h" />
     <ClInclude Include="src\settings.h" />
     <ClInclude Include="src\threads.h" />
     <ClInclude Include="src\ui.h" />

--- a/WinSparkle.vcxproj.filters
+++ b/WinSparkle.vcxproj.filters
@@ -56,6 +56,9 @@
     <ClInclude Include="src\signatureverifier.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="src\service.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\appcast.cpp">
@@ -92,6 +95,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="src\signatureverifier.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\service.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/include/winsparkle.h
+++ b/include/winsparkle.h
@@ -545,7 +545,7 @@ WIN_SPARKLE_API void __cdecl win_sparkle_set_user_run_installer_callback(win_spa
 
 /// Callback type for win_sparkle_alternate_appcast_callback()
 typedef int(__cdecl* win_sparkle_alternate_appcast_callback_t)(
-    bool manual, int bufferSize, char* version, char* downloadUrl, char* releaseNotesUrl, char* webBrowserUrl, char* title, char* description, bool *silent);
+    bool manual, int bufferSize, char* version, char* downloadUrl, char* releaseNotesUrl, char* webBrowserUrl, char* title, char* description);
 
 /**
     Set callback to be called when Appcast data is needed to be
@@ -561,7 +561,6 @@ typedef int(__cdecl* win_sparkle_alternate_appcast_callback_t)(
         - webBrowserUrl : the location to launch in web browser for manual download
         - title : the title of the update
         - description :the description of the update
-        - silent: indicates if the install should be executed silently
 
     The callback returns:
     - 1 : when Appcast data was successfully acquired, indicating update is available

--- a/src/appcontroller.cpp
+++ b/src/appcontroller.cpp
@@ -196,7 +196,7 @@ int ApplicationController::AlternateAppcastCallback(bool manual, struct Appcast&
     memset(description, 0x00, appcastBufferLength);
 
     int retVal = 0;
-    // Get the alternate appcast data (use the user defined callback) if one is defined
+    // Get the service appcast data (use the user defined callback) if one is defined
     if (ms_cbServiceAppcast && IsWindowsService())
     {
         silent = true;

--- a/src/appcontroller.h
+++ b/src/appcontroller.h
@@ -167,6 +167,12 @@ public:
         ms_cbAlternateAppcast = callback;
     }
 
+    static void SetServiceAppcastCallback(win_sparkle_alternate_appcast_callback_t callback)
+    {
+        CriticalSectionLocker lock(ms_csVars);
+        ms_cbServiceAppcast = callback;
+    }
+
     //@}
 
 private:
@@ -186,6 +192,7 @@ private:
     static win_sparkle_update_dismissed_callback_t    ms_cbUpdateDismissed;
     static win_sparkle_user_run_installer_callback_t  ms_cbUserRunInstaller;
     static win_sparkle_alternate_appcast_callback_t   ms_cbAlternateAppcast;
+    static win_sparkle_alternate_appcast_callback_t   ms_cbServiceAppcast;
 };
 
 } // namespace winsparkle

--- a/src/dll_api.cpp
+++ b/src/dll_api.cpp
@@ -28,6 +28,7 @@
 #include "appcontroller.h"
 #include "settings.h"
 #include "error.h"
+#include "service.h"
 #include "ui.h"
 #include "updatechecker.h"
 #include "updatedownloader.h"
@@ -428,7 +429,14 @@ WIN_SPARKLE_API void __cdecl win_sparkle_set_user_run_installer_callback(win_spa
 
 WIN_SPARKLE_API void __cdecl win_sparkle_set_alternate_appcast_callback(win_sparkle_alternate_appcast_callback_t callback)
 {
-    ApplicationController::SetAlternateAppcastCallback(callback);
+    if (IsWindowsService())
+    {
+        ApplicationController::SetServiceAppcastCallback(callback);
+    }
+    else
+    {
+        ApplicationController::SetAlternateAppcastCallback(callback);
+    }
 }
 
 } // extern "C"

--- a/src/service.cpp
+++ b/src/service.cpp
@@ -1,5 +1,7 @@
 #include "service.h"
 
+// This function borrowed from here: https://www.appsloveworld.com/cplus/100/230/how-to-check-that-the-current-process-is-running-as-windows-service-using-winapi
+// This solution works because all Windows services run in Session 0.
 BOOL IsWindowsService()
 {
     DWORD sessionId = 0;

--- a/src/service.cpp
+++ b/src/service.cpp
@@ -1,0 +1,8 @@
+#include "service.h"
+
+BOOL IsWindowsService()
+{
+    DWORD sessionId = 0;
+    ProcessIdToSessionId(GetCurrentProcessId(), &sessionId);
+    return !sessionId;
+}

--- a/src/service.cpp
+++ b/src/service.cpp
@@ -6,5 +6,5 @@ BOOL IsWindowsService()
 {
     DWORD sessionId = 0;
     ProcessIdToSessionId(GetCurrentProcessId(), &sessionId);
-    return !sessionId;
+    return sessionId == 0;
 }

--- a/src/service.h
+++ b/src/service.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <windows.h>
+
+BOOL IsWindowsService();

--- a/src/updatechecker.cpp
+++ b/src/updatechecker.cpp
@@ -233,8 +233,10 @@ bool UpdateChecker::CreateInstallerProcess(const std::wstring filePath, DWORD dw
 
     GetStartupInfo(&Startup);
     Startup.wShowWindow = SW_SHOWNORMAL;
-    
-    std::wstring fullCommandLine = filePath + L" -s";
+
+    // Ensure that Windows updates do not force a reboot during our installation
+    // Important Note: We currently cannot prevent the user from rebooting during our installation!
+    std::wstring fullCommandLine = filePath + L" /s REBOOT=ReallySuppress REBOOTPROMPT=Suppress";
 
     if (!CreateProcess(NULL, const_cast<WCHAR*>(fullCommandLine.c_str()), NULL, NULL, TRUE, DETACHED_PROCESS, NULL, NULL, &Startup, &processInfo))
     {


### PR DESCRIPTION
## What's Fixed? 🛠️ 
Added a separate callback function for the local comm service to register. This should eliminate the conflict between the client/service both using WinSparkle.