### PR TITLE
fix(updater): Resolve crash involving null bool parameter

### DIFF
--- a/include/winsparkle-version.h
+++ b/include/winsparkle-version.h
@@ -32,7 +32,7 @@
 
 #define WIN_SPARKLE_VERSION_MAJOR   0
 #define WIN_SPARKLE_VERSION_MINOR   7
-#define WIN_SPARKLE_VERSION_MICRO   5
+#define WIN_SPARKLE_VERSION_MICRO   6
 
 /**
     Checks if WinSparkle version is at least @a major.@a minor.@a micro.

--- a/include/winsparkle.h
+++ b/include/winsparkle.h
@@ -561,7 +561,7 @@ typedef int(__cdecl* win_sparkle_alternate_appcast_callback_t)(
         - webBrowserUrl : the location to launch in web browser for manual download
         - title : the title of the update
         - description :the description of the update
-        - silent: flag indicating if the the update should be executed silently (by the background comm service) or manually (by the main client app)
+        - silent: flag indicating if the the update should be executed silently (by the background comm service) or interactively (by the main client app)
 
     The callback returns:
     - 1 : when Appcast data was successfully acquired, indicating update is available

--- a/include/winsparkle.h
+++ b/include/winsparkle.h
@@ -545,7 +545,7 @@ WIN_SPARKLE_API void __cdecl win_sparkle_set_user_run_installer_callback(win_spa
 
 /// Callback type for win_sparkle_alternate_appcast_callback()
 typedef int(__cdecl* win_sparkle_alternate_appcast_callback_t)(
-    bool manual, int bufferSize, char* version, char* downloadUrl, char* releaseNotesUrl, char* webBrowserUrl, char* title, char* description, bool *silent);
+    bool manual, int bufferSize, char* version, char* downloadUrl, char* releaseNotesUrl, char* webBrowserUrl, char* title, char* description, char *silent);
 
 /**
     Set callback to be called when Appcast data is needed to be
@@ -561,6 +561,7 @@ typedef int(__cdecl* win_sparkle_alternate_appcast_callback_t)(
         - webBrowserUrl : the location to launch in web browser for manual download
         - title : the title of the update
         - description :the description of the update
+        - silent: flag indicating if the the update should be executed silently (by the background comm service) or manually (by the main client app)
 
     The callback returns:
     - 1 : when Appcast data was successfully acquired, indicating update is available

--- a/src/appcontroller.cpp
+++ b/src/appcontroller.cpp
@@ -184,8 +184,7 @@ int ApplicationController::AlternateAppcastCallback(bool manual, struct Appcast&
     char webBrowserUrl[appcastBufferLength];
     char title[appcastBufferLength];
     char description[appcastBufferLength];
-    bool silent = false;
-    appcast.SilentInstall = false;
+    char silent[appcastBufferLength];
 
     memset(version, 0x00, appcastBufferLength);
     memset(downloadUrl, 0x00, appcastBufferLength);
@@ -193,9 +192,10 @@ int ApplicationController::AlternateAppcastCallback(bool manual, struct Appcast&
     memset(webBrowserUrl, 0x00, appcastBufferLength);
     memset(title, 0x00, appcastBufferLength);
     memset(description, 0x00, appcastBufferLength);
+    memset(silent, 0x00, appcastBufferLength);
 
     int retVal = 0;
-    retVal = ms_cbAlternateAppcast(manual, appcastBufferLength - 1, version, downloadUrl, releaseNotesUrl, webBrowserUrl, title, description, &silent);
+    retVal = ms_cbAlternateAppcast(manual, appcastBufferLength - 1, version, downloadUrl, releaseNotesUrl, webBrowserUrl, title, description, silent);
 
     if (retVal == 1)
     {
@@ -206,7 +206,7 @@ int ApplicationController::AlternateAppcastCallback(bool manual, struct Appcast&
         appcast.WebBrowserURL = webBrowserUrl;
         appcast.Title = title;
         appcast.Description = description;
-        appcast.SilentInstall = silent;
+        silent[0] == '1' ? appcast.SilentInstall = true : appcast.SilentInstall = false;
     }
 
     return retVal;


### PR DESCRIPTION
We've noticed some recent crashes involving a null bool *silent parameter. Unsure of why we're getting this crash but it could be that bool parameters are not fully supported when passed across the application/DLL boundary.
Changing this parameter over to a character string to be consistent with the other parameters should resolve this issue.

<img width="1860" alt="Screenshot 2024-01-30 at 11 45 59 AM" src="https://github.com/CovenantEyes/winsparkle/assets/1682254/fa47f117-6b13-4159-8d09-bcac62e9e070">
